### PR TITLE
Use pickle name if available

### DIFF
--- a/java/src/main/java/io/cucumber/junitxmlformatter/XmlReportData.java
+++ b/java/src/main/java/io/cucumber/junitxmlformatter/XmlReportData.java
@@ -59,7 +59,7 @@ class XmlReportData {
     private final Map<String, String> pickleIdToScenarioAstNodeId = new ConcurrentHashMap<>();
     private final Map<String, String> scenarioAstNodeIdToFeatureName = new ConcurrentHashMap<>();
     private final Map<String, String> stepAstNodeIdToStepKeyWord = new ConcurrentHashMap<>();
-    private final Map<String, String> pickleAstNodeIdToLongName = new ConcurrentHashMap<>();
+    private final Map<String, String> pickleAstNodeIdToNameOrSuffix = new ConcurrentHashMap<>();
 
     void collect(Envelope envelope) {
         envelope.getTestRunStarted().ifPresent(event -> this.testRunStarted = timestampToJavaInstant(event.getTimestamp()));
@@ -131,7 +131,7 @@ class XmlReportData {
         });
 
         String rulePrefix = rule == null ? "" : rule.getName() + " - ";
-        pickleAstNodeIdToLongName.put(scenario.getId(), rulePrefix + scenario.getName());
+        pickleAstNodeIdToNameOrSuffix.put(scenario.getId(), rulePrefix + scenario.getName());
 
         List<Examples> examples = scenario.getExamples();
         for (int examplesIndex = 0; examplesIndex < examples.size(); examplesIndex++) {
@@ -144,7 +144,7 @@ class XmlReportData {
                     suffix.append(currentExamples.getName()).append(" - ");
                 }
                 suffix.append("Example #").append(examplesIndex + 1).append(".").append(exampleIndex + 1);
-                pickleAstNodeIdToLongName.put(currentExample.getId(), rulePrefix + scenario.getName() + suffix);
+                pickleAstNodeIdToNameOrSuffix.put(currentExample.getId(), suffix.toString());
             }
         }
     }
@@ -197,7 +197,7 @@ class XmlReportData {
         Pickle pickle = pickleIdToPickle.get(pickleId);
         List<String> astNodeIds = pickle.getAstNodeIds();
         String pickleAstNodeId = astNodeIds.get(astNodeIds.size() - 1);
-        return pickleAstNodeIdToLongName.getOrDefault(pickleAstNodeId, pickle.getName());
+        return pickle.getName() + pickleAstNodeIdToNameOrSuffix.getOrDefault(pickleAstNodeId, "");
     }
 
     public String getFeatureName(String testCaseStartedId) {


### PR DESCRIPTION
<!---
Thanks for helping to make Cucumber better! 💖

You can feel free to open a "Draft" status pull request if you're not ready for feedback yet.

Don't worry about getting everything perfect! We're here to help and will coach you through
to getting your pull request ready to merge.

The prompts below are for guidance to help you describe your change in a way that is most 
likely to make sense to other people when they are reviewing it. Still, it's just a guide, 
so feel free to delete anything that doesn't feel appropriate, and add anything additional 
that seems like it would provide useful context. 👏🏻
-->

### 🤔 What's changed?

Use the pickle name when constructing the test case name, rather than the raw line of text detected from the source

### ⚡️ What's your motivation? 

<!-- 
What motivated you to propose this change? Does it fix a bug? Add a new feature?
If it fixes an open issue, you can link to the issue here, e.g. "Fixes #99"
-->

If you have a scenario outline like "Creating a <type> database" with examples type: replica set and type: sharded cluster, the JUnit test case names are "Creating a <type> database - Example #1.1" etc. With this change, you will see "Creating a replica set database - ..." etc.

This patch is to solve the problem of test case names not having the expanded step arguments from the examples data table. The current naming convention is covered [here](https://github.com/cucumber/cucumber-junit-xml-formatter#naming-rules-and-examples). The last example shows the generic suffix we'd see otherwise. It's the best you can do since you're operating under the assumption that developer won't reference the step arguments in the scenario outline name, but you still need to provide some way to disambiguate the test case names in the JUnit XML output. However, we typically _do_ reference the step argument in the scenario outline name, meaning the expanded name would actually be useful to us, and the generic example number suffix would just be a bonus, to help disambiguate cases where the developer forgot to reference one of the step arguments from an examples data table in the scenario outline.

The addition of a generic example number as a suffix to the unexpanded scenario outline name is a consequence of the fact that the plugin builds its model of the test run from the source of the feature file, before Cucumber starts breaking it down and executing different scenarios. The scenario name string with the unexpanded step argument reference gets put into a map very early in the test run. As further examples are detected, additional entries point back to the same string, and generic example number suffixes are appended. But notably, the method that sets up the contents of all the various maps from the feature file does not appear to have access to the Pickles, which are the objects that contain the expanded step arguments. Those don't appear to be provided to the plugin until the tests start running, by which point all the data structures have been populated, and no further changes are being made.

Luckily, by the time the JUnit XML is being written out, we have all this information, and the method that determines the final test case name can use the Pickle to name the test. That alone should be good enough for us, but in order to increase the likelihood that this will get accepted upstream, I wanted to preserve the generic suffix to disambiguate cases when there are examples with a different step argument that's never mentioned in the scenario outline name.

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
