### PR TITLE
Fix missing execution steps statuses if same step is called multiple times in a test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+[0.2.1]: https://github.com/cucumber/cucumber-junit-xml-formatter/pull/24
 
 ## [0.2.0] - 2023-04-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-[0.2.1]: https://github.com/cucumber/cucumber-junit-xml-formatter/pull/24
+
+### Fixed
+- Missing execution steps statuses if same step is called multiple times in a test ([#24](https://github.com/cucumber/cucumber-junit-xml-formatter/pull/24) F. Ahadi)
 
 ## [0.2.0] - 2023-04-07
 

--- a/java/src/main/java/io/cucumber/junitxmlformatter/XmlReportWriter.java
+++ b/java/src/main/java/io/cucumber/junitxmlformatter/XmlReportWriter.java
@@ -4,17 +4,16 @@ import io.cucumber.messages.types.Exception;
 import io.cucumber.messages.types.TestStepResult;
 import io.cucumber.messages.types.TestStepResultStatus;
 
+import java.util.List;
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;
 import java.io.Writer;
 import java.text.NumberFormat;
 import java.util.EnumSet;
-import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 
-import static io.cucumber.messages.types.TestStepResultStatus.FAILED;
 import static io.cucumber.messages.types.TestStepResultStatus.PASSED;
 import static io.cucumber.messages.types.TestStepResultStatus.SKIPPED;
 
@@ -126,7 +125,7 @@ class XmlReportWriter {
     }
 
     private void writeStepAndResultList(EscapingXmlStreamWriter writer, String id) throws XMLStreamException {
-        LinkedHashMap<String, String> results = data.getStepsAndResult(id);
+        List<Map.Entry<String, String>> results = data.getStepsAndResult(id);
         if (results.isEmpty()) {
             return;
         }
@@ -136,10 +135,10 @@ class XmlReportWriter {
         writer.newLine();
     }
 
-    private static String createStepResultList(LinkedHashMap<String, String> results) {
+    private static String createStepResultList(List<Map.Entry<String, String>> results) {
         StringBuilder sb = new StringBuilder();
         sb.append("\n");
-        results.entrySet().forEach(r -> {
+        results.forEach(r -> {
             String stepText = r.getKey();
             String status = r.getValue();
             sb.append(stepText);


### PR DESCRIPTION
### 🤔 What's changed?

The xml report formatter now returns the same number of step results as the number of steps in a cucumber test, even if some steps have the same name.
In code :
`XmlReportData.getStepsAndResult()` now returns a `List<Map.Entry<String, String>>` instead of a `LinkedHashMap<String, String>`
`XmlReportWriter.createStepResultList()` now take a `List<Map.Entry<String, String>>` instead of a `LinkedHashMap<String, String>` as parameter


### ⚡️ What's your motivation? 

Fixes: https://github.com/cucumber/cucumber-junit-xml-formatter/issues/23


### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?


### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
