### PR TITLE
Include value from Exception.stacktrace if available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added 
+- Include value from Exception.stacktrace if available ([#30](https://github.com/cucumber/cucumber-junit-xml-formatter/pull/30), M.P. Korstanje)
+
 ### Fixed
 - Do not overwrite results of retried tests ([#29](https://github.com/cucumber/cucumber-junit-xml-formatter/pull/29), M.P. Korstanje)
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>io.cucumber</groupId>
             <artifactId>messages</artifactId>
-            <version>[21.0.1,25.0.0)</version>
+            <version>[24.0.0,25.0.0)</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
### 🤔 What's changed?

Include value from Exception.stacktrace if available. Fall back to the message otherwise.

This does require v24 of the messages in which the stacktrace was added.

### ⚡️ What's your motivation? 

Closes: https://github.com/cucumber/cucumber-junit-xml-formatter/issues/26

### 🏷️ What kind of change is this?

- :zap: New feature (non-breaking change which adds new behaviour)

### ♻️ Anything particular you want feedback on?


### 📋 Checklist:


- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

